### PR TITLE
Include path incorrect when using gpb with Rebar

### DIFF
--- a/src/gpb_compile.erl
+++ b/src/gpb_compile.erl
@@ -1039,7 +1039,7 @@ format_erl(Mod, Defs, AnRes, Opts) ->
          "\n"]
         || DoNif],
        f("-include(\"~s.hrl\").~n", [Mod]),
-       f("-include(\"gpb.hrl\").~n"),
+       f("-include_lib(\"gpb/include/gpb.hrl\").~n"),
        "\n",
        [[f("~s~n", [format_load_nif(Mod, Opts)]),
          "\n"]


### PR DESCRIPTION
Hello Tomas,

I'm using gpb with Rebar. The generated file includes the `gpb.hrl` file directly, so it must be located in the same folder as the generated bindings. However, when you use gpb with Rebar, you have to include the header file with the following command:

```
-include_lib("gpb/include/gpb.hrl").
```

Why did you include the file directly? How have you managed to make it running when using gpb as a dependency?

Great work btw.!

All the best,
Martin
