### PR TITLE
Fixing generate gpb_version.hrl in Mac OS X

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,8 +5,7 @@
  [{compile,
    "sed -e \"s/@vsn@/`git describe --always --tags`/g\""
    "    -e \"s/is expected to be/was/g\""
-   "    -e \"/^%% The version below/"
-   "         i %% DO NOT EDIT -- generated from gpb_version.hrl.in\""
+   "    -e 's/^%% The version below.*/&'$'\\\\\\n%% DO NOT EDIT -- generated from gpb_version.hrl.in/g'"
    "    -e \"/^%% NB: rebar.config depends/ d\""
    "    < include/gpb_version.hrl.in"
    "    > include/gpb_version.hrl "}
@@ -17,3 +16,6 @@
 
 %% XRef checks to perform
 {xref_checks, [undefined_function_calls]}.
+
+%% Clean files
+{clean_files, [".eunit", "ebin/*.beam", "include/gpb_version.hrl"]}.


### PR DESCRIPTION
In Mac OS X the sed command not support `i\` gnu extension. Because of this `rebar compile` is broken.

This patch replaces a `i\` instruction for a more compatible option.
