### PR TITLE
Fixed 'applicatons' type, added 'registered', fixed invalid 'env'

### DIFF
--- a/src/gpb.app.src
+++ b/src/gpb.app.src
@@ -21,6 +21,7 @@
 {application, gpb,
  [{description, "Google protocol buffer compiler and runtime support"},
   {vsn, {cmd, "git describe --always --tags --match '[0-9]*.[0-9]*'"}},
-  {applicatons, [kernel, stdlib]},
-  {modules, []},
-  {env, [gpb, gpb_compile, gpb_scan, gpb_parse]}]}.
+  {modules, [gpb, gpb_compile, gpb_scan, gpb_parse]},
+  {applications, [kernel, stdlib]},
+  {registered, []},
+  {env, []}]}.


### PR DESCRIPTION
Got an error when using gpb with Elixir and Relex. Relex was unable to parse gpb.app.src.
