### PR TITLE
Fail with an `expected_msg' error also for optional fields

### DIFF
--- a/src/gpb_compile.erl
+++ b/src/gpb_compile.erl
@@ -2631,7 +2631,7 @@ field_verifiers(FVars) ->
                        Replacements);
              optional ->
                  ?expr(if '<F>' == undefined -> ok;
-                          true -> '<verify-fn>'('<F>', ['<FName>', Path])
+                          true -> '<verify-fn>'('<F>', ['<FName>' | Path])
                        end,
                        Replacements)
          end

--- a/test/gpb_compile_tests.erl
+++ b/test/gpb_compile_tests.erl
@@ -517,6 +517,25 @@ only_enums_no_msgs_test() ->
     [e] = M:get_enum_names(),
     unload_code(M).
 
+%% --- message type errors ----------
+message_type_errors_test() ->
+    M = compile_iolist(["message m1 {"
+                        "  required m2 f1 = 1;",
+                        "  optional m2 f2 = 2;",
+                        "}",
+                        "message m2 {"
+                        "  required uint32 f1 = 1;",
+                        "}",
+                        "message m3 {"
+                        "  required uint32 f1 = 1;",
+                        "}"]),
+    ?assertError({gpb_type_error, {{expected_msg, m2}, _}},
+                 M:verify_msg({m1,{m3,1},{m2,1}})),
+    ?assertError({gpb_type_error, {{expected_msg, m2}, _}},
+                 M:verify_msg({m1,{m2,1},{m3,1}})),
+    ?assertError({gpb_type_error, {not_a_known_message, _}}, M:verify_msg({x})),
+    unload_code(M).
+
 %% --- Returning/reporting warnings/errors tests ----------
 %% ... when compiling to file/binary
 %% ... when there are/aren't warnings/errors


### PR DESCRIPTION
Assume the following message definitions:

```
message m1 {
  required m2 f1 = 1;
  optional m2 f2 = 2;
}
message m2 {
  required uint32 f1 = 1;
}
message m3 {
  required uint32 f1 = 1;
}
```

gpb fails with this error when the required field f1 is assigned the
wrong message type:

```
{gpb_type_error, {{expected_msg,m2}, [{value,{m3,1}}, {path,'m1.f1'}]}}
```

The same did not apply to the optional field f2 however, where gpb
instead crashed.  gpb now fails with a proper error also for optional
fields.
