### PR TITLE
Allow ERL and ERLC override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@
 
 SHELL = /bin/sh
 
-ERL  = erl
-ERLC = erlc
+ERL  ?= erl
+ERLC ?= erlc
 
 GPB_PREFIX =
 


### PR DESCRIPTION
Use ?= to allow for erl and erlc programs to be explicitly set by parent makefile.
