### PR TITLE
Fix records type declaration

### DIFF
--- a/src/gpb_compile.erl
+++ b/src/gpb_compile.erl
@@ -3492,7 +3492,7 @@ format_enum_typespec(Enum, Enumeration) ->
     string:join(["'"++atom_to_list(EName)++"'" || {EName, _} <- Enumeration], " | ")]).
 
 format_record_typespec(records, Msg, _Fields, _Defs) ->
-  ?f("-type '~s'() :: #~s{}.", [Msg, Msg]);
+  ?f("-type '~s'() :: #'~s'{}.", [Msg, Msg]);
 format_record_typespec(maps, Msg, Fields, Defs) ->
   ?f("-type '~s'() :: ~n"
      "      #{~s~n"


### PR DESCRIPTION
```
src/delivery_info.erl:42: syntax error before: DeliveryInfo
```
```
42: -type 'DeliveryInfo'() :: #DeliveryInfo{}.
```
should be
```
42: -type 'DeliveryInfo'() :: #'DeliveryInfo'{}.
```