### PR TITLE
Accept binary strings

### DIFF
--- a/src/gpb.erl
+++ b/src/gpb.erl
@@ -688,7 +688,7 @@ verify_float(V, _) when is_integer(V) -> ok;
 verify_float(V, Path) ->
     mk_type_error(bad_floating_point_value, V, Path).
 
-verify_string(V, Path) when is_list(V) ->
+verify_string(V, Path) when is_list(V); is_binary(V) ->
     try
         unicode:characters_to_binary(V),
         ok

--- a/src/gpb_compile.erl
+++ b/src/gpb_compile.erl
@@ -3097,7 +3097,7 @@ format_float_verifier(FlType) ->
 format_string_verifier() ->
     gpb_codegen:format_fn(
       mk_fn(v_type_, string),
-      fun(S, Path) when is_list(S) ->
+      fun(S, Path) when is_list(S); is_binary(S) ->
               try
                   unicode:characters_to_binary(S),
                   ok


### PR DESCRIPTION
Bumped into this while running property tests for encode/decode equality. I compiled my proto files with `-strbin` option such that strings are returned as binaries. I was expecting to be able put binary strings in and get binary strings out but always get the `bad_unicode_strings` error. As far as I understand `unicode:characters_to_binary` is idempotent, so this change doesn't change any fundamentals. I couldn't quite find a spot to place a test but I'm open to add some if you would point me into the right direction.

