### PR TITLE
Fix `gpb.app` file generation for hex.pm

### DIFF
--- a/helpers/package-for-hex.pm
+++ b/helpers/package-for-hex.pm
@@ -72,7 +72,7 @@ cd "$d"
 ## Include that version in the package, verbatim
 
 ## Fixup the vsn tag in the src/gpb.app.src
-"$script_path"/xsillyed src/gpb.app.src key:vsn change-to:' {vsn,"'"$vsn"'"}'
+"$script_path"/xsillyed src/gpb.app.src key:vsn change-to:' {vsn,"'"$vsn"'"},'
 ## Fixup vsn substitution in include/gpb_version.hrl
 "$script_path"/xsillyed rebar.config.script key:pre_hooks delete-paragraph
 build/mk_version_hrl < include/gpb_version.hrl.in > include/gpb_version.hrl
@@ -122,4 +122,4 @@ else
     (LC_ALL=en_US.utf-8 MIX_EXS=package.exs mix hex.publish)
 fi
 
-/bin/rm -rf 
+/bin/rm -rf


### PR DESCRIPTION
`gpb` packages uploaded to hex.pm are broken. Their `gpb.app` files are missing a comma:
```
{application, gpb,
 [{description, "Google protocol buffer compiler and runtime support"},
 {vsn,"3.18.1"}
  {modules, [gpb, gpb_compile, gpb_scan, gpb_parse, gpb_codegen]},
  {applications, [kernel, stdlib]},
  {registered, []},
  {env, []}]}.
```

I couldn't test this because of the the proper version restrictions and I don't have Elixir installed. 

In the light of rebar3 being able to use pure Erlang packages from hex.pm I think it is definitely worth fixing this.