### PR TITLE
add support for extend otherpackage.Message{...}

### DIFF
--- a/src/gpb_parse.yrl
+++ b/src/gpb_parse.yrl
@@ -432,6 +432,10 @@ resolve_refs(Defs) ->
                   {NewRPCs, Acc2} =
                       resolve_rpc_refs(Rpcs, Defs, Root, FullName, Acc),
                   {{{service,FullName}, NewRPCs}, Acc2};
+             ({{extend,FullName}, Fields}, Acc) ->
+                  {NewFields, Acc2} =
+                      resolve_field_refs(Fields, Defs, Root, FullName, Acc),
+                  {{{extend,FullName}, NewFields}, Acc2};
              (OtherElem, Acc) ->
                   {OtherElem, Acc}
           end,


### PR DESCRIPTION
Previously `gpb` would crash parsing `Foo.FooMessage`; it being an `identifier` rather than a `name`. This is a bug. The fix is somewhat ugly since the first pass processing each file one at a time adds some incorrect namespacing that is now stripped later on and extended correctly.
```protobuf
//foo.proto
package foo;
message FooMessage {
    required int32 foo = 0;
}
//bar.proto
package bar;
import "foo.proto";
extend foo.FooMessage {
    optional int32 bar = 100;
}
```