### PR TITLE
support extend inside a message body, rough cut

### DIFF
--- a/src/gpb_parse.yrl
+++ b/src/gpb_parse.yrl
@@ -142,6 +142,8 @@ msg_elem -> message_def:                '$1'.
 msg_elem -> enum_def:                   '$1'.
 msg_elem -> extensions_def:             {extensions,lists:sort('$1')}.
 msg_elem -> oneof_def:                  '$1'.
+msg_elem -> extend identifier '{' msg_elems '}':
+                                 {{extend,identifier_name('$2')},'$4'}.
 
 fidentifier -> identifier:              '$1'.
 fidentifier -> package:                 kw_to_identifier('$1').
@@ -410,6 +412,10 @@ flatten_fields(FieldsOrDefs, FullName) ->
                             {[F | Fs], Ds};
                        (#gpb_oneof{}=O, {Fs,Ds}) ->
                             {[O | Fs], Ds};
+                       ({{extend, _Msg},_}=Def, {Fs,Ds}) ->
+                            QDefs = flatten_qualify_defnames(
+                                      [Def], drop_last_level(FullName)),
+                            {Fs, QDefs ++ Ds};
                        (Def, {Fs,Ds}) ->
                             QDefs = flatten_qualify_defnames([Def], FullName),
                             {Fs, QDefs++Ds}

--- a/test/gpb_parse_tests.erl
+++ b/test/gpb_parse_tests.erl
@@ -371,6 +371,39 @@ parses_extending_msgs_test() ->
                                    occurrence=optional}]}] =
         do_process_sort_defs(Defs).
 
+parses_nested_extending_msgs_test() ->
+    {ok,Defs} = parse_lines(["message m1 {",
+                             "  required uint32 f1=1 [default=17];",
+                             "  extensions 200 to 299;",
+                             "  extend m1 {",
+                             "    optional uint32 f2=2;",
+                             "  }",
+                             "}"]),
+    [{{extensions,m1},[{200,299}]},
+     {{msg,m1},       [#?gpb_field{name=f1, fnum=1, rnum=2, opts=[{default,17}],
+                                   occurrence=required},
+                       #?gpb_field{name=f2, fnum=2, rnum=3, opts=[],
+                                   occurrence=optional}]}] =
+        do_process_sort_defs(Defs).
+
+parses_nested_extending_msgs_in_package_test() ->
+    {ok,Defs} = parse_lines(["package p1.p2;",
+                             "message m1 {",
+                             "  required uint32 f1=1 [default=17];",
+                             "  extensions 200 to 299;",
+                             "  extend m1 {",
+                             "    optional uint32 f2=2;",
+                             "  }",
+                             "}"]),
+    [{package,'p1.p2'},
+     {{extensions,'p1.p2.m1'},[{200,299}]},
+     {{msg,'p1.p2.m1'},
+      [#?gpb_field{name=f1, fnum=1, rnum=2, opts=[{default,17}],
+                   occurrence=required},
+       #?gpb_field{name=f2, fnum=2, rnum=3, opts=[],
+                   occurrence=optional}]}] =
+        do_process_sort_defs(Defs, [use_packages]).
+
 parses_service_test() ->
     {ok,Defs} = parse_lines(["message m1 {required uint32 f1=1;}",
                              "message m2 {required uint32 f2=1;}",


### PR DESCRIPTION
This is a rough cut at resolving #42. I've added a test where the message gets extended inside its own definition and gotten the test to pass.
My biggest concern at this point is that I'm manually qualifying the message name (making it a root message name) because I wasn't sure of the right way to qualify it without applying the message name that it is nested inside of. 
Can anyone point me towards a better way of handling the message name qualification?