### PR TITLE
add a test for extending a message with a nested message

### DIFF
--- a/src/gpb_parse.yrl
+++ b/src/gpb_parse.yrl
@@ -305,13 +305,12 @@ post_process_one_file(Defs, Opts) ->
     end.
 
 post_process_all_files(Defs, Opts) ->
-    case resolve_names(Defs) of
+    case resolve_names(extend_msgs(Defs)) of
         {ok, Defs2} ->
             {ok, possibly_prefix_suffix_msgs(
                    normalize_msg_field_options( %% Sort it?
                      enumerate_msg_fields(
-                       reformat_names(
-                         extend_msgs(Defs2)))),
+                       reformat_names(Defs2))),
                    Opts)};
         {error, Reasons} ->
             {error, Reasons}

--- a/test/gpb_parse_tests.erl
+++ b/test/gpb_parse_tests.erl
@@ -386,6 +386,26 @@ parses_nested_extending_msgs_test() ->
                                    occurrence=optional}]}] =
         do_process_sort_defs(Defs).
 
+parses_extending_msgs_with_nested_msg_test() ->
+    {ok,Defs} = parse_lines(["message m1 {",
+                             "  required uint32 f1=1 [default=17];",
+                             "  extensions 200 to 299;",
+                             "}",
+                             "message m2 {",
+                             "  optional uint32 num = 1;",
+                             "}",
+                             "extend m1 {",
+                             "  optional m2 ext_m2 = 200;",
+                             "}"]),
+    [{{extensions,m1},[{200,299}]},
+     {{msg,m1},       [#?gpb_field{name=f1, fnum=1, rnum=2, opts=[{default,17}],
+                                   occurrence=required},
+                       #?gpb_field{name=ext_m2, fnum=200, rnum=3, opts=[],
+                                   occurrence=optional, type={msg, m2}}]},
+     {{msg,m2},       [#?gpb_field{name=num, fnum=1, rnum=2, opts=[],
+                                   occurrence=optional}]}] =
+        do_process_sort_defs(Defs).
+
 parses_nested_extending_msgs_in_package_test() ->
     {ok,Defs} = parse_lines(["package p1.p2;",
                              "message m1 {",


### PR DESCRIPTION
The last two "issues" I found turned out to be my misunderstanding, but this time I think I have found something I can actually improve. I have a proto message that adds a nested message in an `extend` block. When I do this the `{ref, other_message}` does not get replaced with a `{msg, other_message}` during the `post_process_all_files/2` step.

It looks like there isn't a test case for this use case and when I added one it leaves the `{ref, other_message}`. Do you have any suggestions about how to tackle this one? I'm happy to contribute a fix here, just want to verify that this is an issue worth fixing first :smile: