### PR TITLE
Small benchmark Makefile changes

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -26,18 +26,22 @@ ifdef NIFS
   nif_opt = -nif
   tmp/msg.beam: tmp/msg.nif.so
   tmp/d.beam: tmp/d.nif.so
+  PROTOBUF_CFLAGS ?= $(shell pkg-config --cflags protobuf)
+  PROTOBUF_LDFLAGS ?= $(shell pkg-config --libs protobuf)
+  PROTOC ?= $(shell which protoc)
 ifdef PROTOHOME
-  protohome = $(PROTOHOME)
+  PROTOBUF_CFLAGS := "-I$(PROTOHOME)/src"
+  PROTOBUF_LDFLAGS := "-L$(PROTOHOME)/src/.libs"
+  PROTOC ?= "$(PROTOHOME)/src/protoc"
 else
-  protohome = /usr/local/src/protobuf
-endif
-ifdef PROTOC
-  protoc = $(PROTOC)
-else
-  protoc = $(protohome)/src/protoc
+  PROTOBUF_CFLAGS ?= "-I/usr/local/src/protobuf/src"
+  PROTOBUF_LDFLAGS ?= "-L/usr/local/src/protobuf/src/.libs -lprotobuf -pthread -lpthread"
 endif
 else
   nif_opt =
+  undefine PROTOBUF_CFLAGS
+  undefine PROTOBUF_LDFLAGS
+  undefine PROTOC
 endif
 
 ifdef MAPS
@@ -46,9 +50,7 @@ else
   maps_opt =
 endif
 
-get_protolib = $(if $(shell grep 'option.*optimize_for.*LITE_RUNTIME' $(1)),protobuf-lite,protobuf)
-
-all:	benchmarks-code
+all: benchmarks-code
 
 benchmarks-code: tmp/msg.beam tmp/d.beam
 
@@ -69,14 +71,12 @@ tmp/%.beam: tmp/%.erl
 		$(patsubst tmp/%,%,$<)
 
 tmp/%.nif.so: %.proto
-	$(protoc) --cpp_out=tmp/ $*.proto
-	$(CXX) -g -fPIC -O3 -I$(protohome)/src -o tmp/$*.pb.o -c tmp/$*.pb.cc
-	$(CXX) -g -fPIC -Wall -O3 -I$(protohome)/src \
+	$(PROTOC) --cpp_out=tmp/ $*.proto
+	$(CXX) -g -fPIC -O3 $(PROTOBUF_CFLAGS) $(CXXFLAGS) -o tmp/$*.pb.o -c tmp/$*.pb.cc
+	$(CXX) -g -fPIC -Wall -O3 $(PROTOBUF_CFLAGS) $(CXXFLAGS) \
 	  -o tmp/$*.nif.o -c tmp/$*.nif.cc
-	$(CXX) -g -fPIC -shared -O3 -Wall -I$(protohome)/src -o $@ \
-	  tmp/$*.nif.o tmp/$*.pb.o \
-	  -L$(protohome)/src/.libs -l$(call get_protolib,$*.proto) \
-	  -Wl,-rpath=$(protohome)/src/.libs
+	$(CXX) -g -fPIC -shared -O3 -Wall $(PROTOBUF_CFLAGS) $(CXXFLAGS) -o $@ \
+	  tmp/$*.nif.o tmp/$*.pb.o $(PROTOBUF_LDFLAGS)
 clean:
 	$(RM) -r tmp
 


### PR DESCRIPTION
* Use pkg-config if present to get protobuf lib information.
* Use `which` to find `protoc` command, else use `PROTOC` or `PROTOHOME`
* Pass `CXXFLAGS` to C++ compiler so that include path to `erl_nif.h` can be specified.
* Remove call to detect if lite lib should be used as the `LITE_RUNTIME` option is not present in `msg.proto`

Command used to compile using the system protobuf lib 2.6.1 (on Arch Linux):

```sh
git clean -fxd; make NIFS=1 CXXFLAGS='-I/home/erlang/installs/18.3-hipe/usr/include'
```

Command used to test using protobuf installed to`$HOME/opt/protobuf/3.0.0-beta-3`:

```sh
$ git clean -fxd; make NIFS=1 PROTOC="$HOME/opt/protobuf/3.0.0-beta-3/bin/protoc" PROTOBUF_CFLAGS="-I$HOME/opt/protobuf/3.0.0-beta-3/include" PROTOBUF_LDFLAGS="-L$HOME/opt/protobuf/3.0.0-beta-3/lib -lprotobuf -pthread -lpthread" CXXFLAGS='-pthread -lpthread -I/home/erlang/installs/18.3-hipe/usr/include'
Removing tmp/
[ -d tmp ] || mkdir tmp
erl -boot start_clean -pa ../ebin -noshell -noinput +B \
        -v never -c false -I`pwd` -o tmp -nif  \
        -s gpb_compile c msg.proto
/home/lbakken/opt/protobuf/3.0.0-beta-3/bin/protoc --cpp_out=tmp/ msg.proto
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: msg.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
g++ -g -fPIC -O3 -I/home/lbakken/opt/protobuf/3.0.0-beta-3/include -pthread -lpthread -I/home/erlang/installs/18.3-hipe/usr/include -o tmp/msg.pb.o -c tmp/msg.pb.cc
g++ -g -fPIC -Wall -O3 -I/home/lbakken/opt/protobuf/3.0.0-beta-3/include -pthread -lpthread -I/home/erlang/installs/18.3-hipe/usr/include \
  -o tmp/msg.nif.o -c tmp/msg.nif.cc
g++ -g -fPIC -shared -O3 -Wall -I/home/lbakken/opt/protobuf/3.0.0-beta-3/include -pthread -lpthread -I/home/erlang/installs/18.3-hipe/usr/include -o tmp/msg.nif.so \
  tmp/msg.nif.o tmp/msg.pb.o -L/home/lbakken/opt/protobuf/3.0.0-beta-3/lib -lprotobuf -pthread -lpthread
cd tmp; erlc -Wall  -I../../include +debug_info \
        msg.erl

(18.3-hipe)lbakken@brahms ~/Projects/src/gpb/benchmarks (fixes/lrb/cxxflags-benchmarks *=)
$ LD_LIBRARY_PATH="$HOME/opt/protobuf/3.0.0-beta-3/lib" ldd tmp/msg.nif.so
        linux-vdso.so.1 (0x00007ffd3eb36000)
        libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007fd2d9d9a000)
        libprotobuf.so.10 => /home/lbakken/opt/protobuf/3.0.0-beta-3/lib/libprotobuf.so.10 (0x00007fd2d9968000)
        libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007fd2d95e1000)
        libm.so.6 => /usr/lib/libm.so.6 (0x00007fd2d92dc000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007fd2d90c6000)
        libc.so.6 => /usr/lib/libc.so.6 (0x00007fd2d8d25000)
        /usr/lib64/ld-linux-x86-64.so.2 (0x0000563a23c59000)
        libz.so.1 => /usr/lib/libz.so.1 (0x00007fd2d8b0e000)
```

Command used to test using protobuf in its `src` dir:

```sh
 make NIFS=1 PROTOHOME="$HOME/Projects/src/protobuf" CXXFLAGS='-I/home/erlang/installs/18.3-hipe/usr/include'
```