### PR TITLE
Accept 0 and 1 as boolean values

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,34 +173,17 @@ The generated C++ core was compiled with -O3.
 Mapping of protocol buffer datatypes to erlang
 ----------------------------------------------
 
-    .proto type           Erlang type
-    ----------------------------------------------------------------
-    double, float         floating point number | infinity | '-infinity' | nan
-                          when encoding, integers, too, are accepted
-    ----------------------------------------------------------------
-    int32, int64,
-    uint32, uint64,
-    sint32, sint64,
-    fixed32, fixed64,
-    sfixed32, sfixed64    integer
-    ----------------------------------------------------------------
-    bool                  true | false
-    ----------------------------------------------------------------
-    enum                  atom
-    ----------------------------------------------------------------
-    message               record (thus tuple)
-                          or maps, if the maps (-maps) option is specified
-    ----------------------------------------------------------------
-    string                unicode string, thus list of integers
-                          or binaries, if the strings_as_binaries (-strbin)
-                          option is specified
-    ----------------------------------------------------------------
-    bytes                 binary
-    ----------------------------------------------------------------
-    oneof                 {ChosenFieldName, Value}
-    ----------------------------------------------------------------
-    map<_,_>              An unordered list of 2-tuples: [{Key,Value}]
-                          or a map, if the maps (-maps) option is specified
+`.proto` type          | Erlang type
+---------------------- | -------------------------------------------------------------
+`double`, `float`      | `float() | infinity | '-infinity' | nan`<br>  when encoding, integers, too, are accepted
+`int32`, `int64`,<br>`uint32`, `uint64`,<br>`sint32`, `sint64`,<br>`fixed32`, `fixed64`,<br>`sfixed32`, `sfixed64`|`integer()`
+`bool`                 | `true` \| `false`<br>&nbsp;&nbsp;0 and 1 may be used as input data prior to serialization<br>&nbsp;&nbsp;`gpb` will always deserialize to the atom values
+`enum`                 | `atom()`
+`message`              | record (thus `tuple()`)<br>&nbsp;&nbsp;or maps, if the maps (`-maps`) option is specified
+`string`               | unicode string, thus list of integers<br>&nbsp;&nbsp;or binaries, if the `strings_as_binaries` (`-strbin`)<br>&nbsp;&nbsp;option is specified
+`bytes`                | `binary()`
+`oneof`                | `{ChosenFieldName, Value}`
+`map<_,_>`             | An unordered list of 2-tuples: `[{Key,Value}]`<br>&nbsp;&nbsp;or a map, if the maps (`-maps`) option is specified
 
 
 Interaction with rebar

--- a/src/gpb.erl
+++ b/src/gpb.erl
@@ -596,8 +596,10 @@ encode_value(Value, Type, MsgDefs)                                             -
         uint64 ->
             encode_varint(Value);
         bool ->
-            if Value     -> encode_varint(1);
-               not Value -> encode_varint(0)
+            if Value       -> encode_varint(1);
+               not Value   -> encode_varint(0);
+               Value =:= 1 -> encode_varint(1);
+               Value =:= 0 -> encode_varint(0)
             end;
         {enum, _EnumName}=Key ->
             {value, {Key, EnumValues}} = lists:keysearch(Key, 1, MsgDefs),
@@ -787,6 +789,8 @@ verify_int(V, {S,Bits}, Path) ->
 
 verify_bool(true,  _) -> ok;
 verify_bool(false, _) -> ok;
+verify_bool(1,  _) -> ok;
+verify_bool(0, _) -> ok;
 verify_bool(V, Path) ->
     mk_type_error(bad_boolean_value, V, Path).
 

--- a/test/gpb_compile_tests.erl
+++ b/test/gpb_compile_tests.erl
@@ -1387,6 +1387,7 @@ nif_code_test_() ->
          {"Nif enums in msgs", fun nif_enum_in_msg/0},
          {"Nif enums with pkgs", fun nif_enum_with_pkgs/0},
          {"Nif with strbin", fun nif_with_strbin/0},
+         {"Nif with booleans", fun nif_with_booleans/0},
          {"Nif and +-Inf/NaN", fun nif_with_non_normal_floats/0},
          {"Error if both Any translations and nif",
           fun error_if_both_any_translations_and_nif/0}])).
@@ -1662,6 +1663,31 @@ nif_with_strbin() ->
                         ?assertEqual(OrigMsgB, MMDecoded),
                         ?assertEqual(OrigMsgS, GMDecoded),
                         ?assertEqual(OrigMsgB, MGDecoded)
+                end)
+      end).
+
+nif_with_booleans() ->
+    with_tmpdir(
+      fun(TmpDir) ->
+              M = gpb_nif_with_booleans,
+              DefsTxt = lf_lines(["message ntest3 {",
+                                  "    required bool b = 1;",
+                                  "}"]),
+              Defs = parse_to_proto_defs(DefsTxt),
+              {ok, Code} = compile_nif_msg_defs(M, DefsTxt, TmpDir, []),
+              in_separate_vm(
+                TmpDir, M, Code,
+                fun() ->
+                        OrigMsgInt = {ntest3,1},
+                        OrigMsgAtom = {ntest3,true},
+                        MEncoded  = M:encode_msg(OrigMsgInt),
+                        GEncoded  = gpb:encode_msg(OrigMsgInt, Defs),
+                        MMDecoded = M:decode_msg(MEncoded, ntest3),
+                        GMDecoded = gpb:decode_msg(MEncoded, ntest3, Defs),
+                        MGDecoded = M:decode_msg(GEncoded, ntest3),
+                        ?assertEqual(OrigMsgAtom, MMDecoded),
+                        ?assertEqual(OrigMsgAtom, GMDecoded),
+                        ?assertEqual(OrigMsgAtom, MGDecoded)
                 end)
       end).
 

--- a/test/gpb_parse_tests.erl
+++ b/test/gpb_parse_tests.erl
@@ -844,7 +844,11 @@ verify_succeeds_for_bool_in_default_test() ->
     ok = do_parse_verify_defs(
            ["message m1 { required bool f1 = 1 [default=true]; }"]),
     ok = do_parse_verify_defs(
-           ["message m1 { required bool f1 = 1 [default=false]; }"]).
+           ["message m1 { required bool f1 = 1 [default=false]; }"]),
+    ok = do_parse_verify_defs(
+           ["message m1 { required bool f1 = 1 [default=1]; }"]),
+    ok = do_parse_verify_defs(
+           ["message m1 { required bool f1 = 1 [default=0]; }"]).
 
 verify_catches_invalid_bool_in_default_1_test() ->
     {error, [_]} = Error =
@@ -863,7 +867,14 @@ verify_catches_invalid_bool_in_default_2_test() ->
 verify_catches_invalid_bool_in_default_3_test() ->
     {error, [_]} = Error =
         do_parse_verify_defs(
-          ["message m1 { required bool f1 = 1 [default=1]; }"]),
+          ["message m1 { required bool f1 = 1 [default=2]; }"]),
+    Msg = verify_flat_string(gpb_parse:format_post_process_error(Error)),
+    verify_strings_present(Msg, ["m1", "f1"]).
+
+verify_catches_invalid_bool_in_default_4_test() ->
+    {error, [_]} = Error =
+        do_parse_verify_defs(
+          ["message m1 { required bool f1 = 1 [default=-1]; }"]),
     Msg = verify_flat_string(gpb_parse:format_post_process_error(Error)),
     verify_strings_present(Msg, ["m1", "f1"]).
 

--- a/test/gpb_tests.erl
+++ b/test/gpb_tests.erl
@@ -556,8 +556,18 @@ encode_msg_with_bool_field_test() ->
                    [{{msg,m1}, [#?gpb_field{name=a, fnum=1, rnum=#m1.a,
                                             type=bool, occurrence=required,
                                             opts=[]}]}]),
+    <<8,1>> =
+        encode_msg(#m1{a = 1},
+                   [{{msg,m1}, [#?gpb_field{name=a, fnum=1, rnum=#m1.a,
+                                            type=bool, occurrence=required,
+                                            opts=[]}]}]),
     <<8,0>> =
         encode_msg(#m1{a = false},
+                   [{{msg,m1}, [#?gpb_field{name=a, fnum=1, rnum=#m1.a,
+                                            type=bool, occurrence=required,
+                                            opts=[]}]}]),
+    <<8,0>> =
+        encode_msg(#m1{a = 0},
                    [{{msg,m1}, [#?gpb_field{name=a, fnum=1, rnum=#m1.a,
                                             type=bool, occurrence=required,
                                             opts=[]}]}]).


### PR DESCRIPTION
Accept 0 and 1 for false / true boolean values.

Related to #63 

Questions -

* These changes will also allow `0` and `1` as `default` values, which isn't part of the PB spec. This doesn't seem to be the end of the world, though. What do you think @tomas-abrahamsson ?
* Could you point me to the tests to show binary data being decoded to `true` and `false` atoms? I couldn't find them, and just wanted to verify.

Thanks!