### PR TITLE
Snake case support, by_proto prefix, oneof/maps fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+_build
 /ebin/*.beam
 /test/*.beam
 /erl_crash.dump

--- a/build/compile_descriptor
+++ b/build/compile_descriptor
@@ -20,20 +20,26 @@ is_up_to_date () {
 
 set -e
 
+if [ -d "./ebin" ]; then
+    OUT="./ebin"
+else
+    OUT="$REBAR_DEPS_DIR/gpb/ebin"
+fi
+
 is_up_to_date descr_src/gpb_descriptor.erl \
-	      priv/proto3/google/protobuf/descriptor.proto || \
+          priv/proto3/google/protobuf/descriptor.proto || \
     ( echo "Compiling descriptor.proto..."
-    erl +B -noinput -pa ebin \
+    erl +B -noinput -pa $OUT \
         -I priv/proto3/google/protobuf -o descr_src \
-	-modprefix gpb_ \
+    -modprefix gpb_ \
         -s gpb_compile c descriptor.proto ) || exit $?
-is_up_to_date ebin/gpb_descriptor.beam descr_src/gpb_descriptor.erl || \
+is_up_to_date $OUT/gpb_descriptor.beam descr_src/gpb_descriptor.erl || \
     ( echo "Compiling gpb_descriptor.erl..."
-    erlc -Idescr_src -Iinclude -o ebin +debug_info \
+    erlc -Idescr_src -Iinclude -o $OUT +debug_info \
         descr_src/gpb_descriptor.erl ) || exit $?
-is_up_to_date ebin/gpb_compile_descr.beam \
+is_up_to_date $OUT/gpb_compile_descr.beam \
     descr_src/gpb_compile_descr.erl \
     descr_src/gpb_descriptor.hrl || \
     ( echo "Compiling gpb_compile_descr.erl..."
-    erlc -Idescr_src -Iinclude -o ebin +debug_info \
-	descr_src/gpb_compile_descr.erl ) || exit $?
+    erlc -Idescr_src -Iinclude -o $OUT +debug_info \
+    descr_src/gpb_compile_descr.erl ) || exit $?

--- a/src/gpb_compile.erl
+++ b/src/gpb_compile.erl
@@ -92,6 +92,7 @@ file(File) ->
 %%                   {erlc_compile_options,string()} |
 %%                   {msg_name_prefix, string() | atom()} |
 %%                   {msg_name_suffix, string() | atom()} |
+%%                   {msg_name_to_snake_case, boolean()} |
 %%                   {msg_name_to_lower, boolean()} |
 %%                   {module_name_prefix, string() | atom()} |
 %%                   {module_name_suffix, string() | atom()} |

--- a/test/gpb_compile_tests.erl
+++ b/test/gpb_compile_tests.erl
@@ -105,7 +105,8 @@ parses_file_to_binary_test() ->
 
 parses_file_to_msg_defs_test() ->
     Contents = <<"message Msg { required uint32 field1 = 1; }\n">>,
-    {ok, [{{msg,'Msg'},[#?gpb_field{}]}]=MsgDefs} =
+    {ok, [{{msg,'Msg'},[#?gpb_field{}]},
+          {{msg_containment,"X"},['Msg']}]=MsgDefs} =
         gpb_compile:file(
           "X.proto",
           [mk_fileop_opt([{read_file, fun(_) -> {ok, Contents} end}]),
@@ -280,7 +281,7 @@ code_generation_when_submsg_size_is_known_at_compile_time_test() ->
     unload_code(M2).
 
 code_generation_when_map_enum_size_is_unknown_at_compile_time_test() ->
-    %% calculation of whether e_varint is needed or not when only 
+    %% calculation of whether e_varint is needed or not when only
     %% an enum needs it, when that enum is in a map
     Defs = [{{msg,m1}, [#?gpb_field{name=a, type={map,bool,{enum,e1}},
                                     fnum=1, rnum=2, occurrence=repeated,
@@ -350,7 +351,7 @@ introspection_defs_as_proplists_test() ->
       {opts,       []}]] = PL = M:find_msg_def(msg1),
     [{{msg, msg1}, PL}] = M:get_msg_defs(),
     [s1, s2] = M:get_service_names(),
-    {{service, s1}, [[{name, req1}, {input, 'msg1'}, {output, 'msg1'}], 
+    {{service, s1}, [[{name, req1}, {input, 'msg1'}, {output, 'msg1'}],
                      [{name, req2}, {input, 'msg1'}, {output, 'msg1'}]]} = M:get_service_def(s1),
     {{service, s2}, [[{name, req2}, {input, 'msg1'}, {output, 'msg1'}]]} = M:get_service_def(s2),
     [{name, req1}, {input, 'msg1'}, {output, 'msg1'}] = M:find_rpc_def(s1, req1),

--- a/test/gpb_parse_tests.erl
+++ b/test/gpb_parse_tests.erl
@@ -799,6 +799,22 @@ can_tolower_record_names_test() ->
                  output=msg2} %% .. and result msgs to be to-lower
       ]}] = do_process_sort_defs(Defs, [msg_name_to_lower]).
 
+can_to_snake_record_names_test() ->
+    {ok, Defs} = parse_lines(["message MsgName1 {required MsgName2   f1=1;}",
+                              "message MsgName2 {required uint32 g1=1;}",
+                              "service SvcName1 {",
+                              "  rpc req(MsgName1) returns (MsgName2) {};",
+                              "}",
+                              "extend Msg1 { optional uint32 fm2=2; }"]),
+    [{{msg,msg_name_1}, [#?gpb_field{name=f1, type={msg,msg_name_2}},
+                   #?gpb_field{name=fm2}]},
+     {{msg,msg_name_2}, [#?gpb_field{name=g1}]},
+     {{service,svc_name_1},
+      [#?gpb_rpc{name=req,
+                 input=msg_name_1,  %% both argument ...
+                 output=msg_name_2} %% .. and result msgs to be to-lower
+      ]}] = do_process_sort_defs(Defs, [msg_name_to_lower]).
+
 can_tolower_record_names_with_packages_test() ->
     {ok, Defs} = parse_lines(["package Pkg1;",
                               "message Msg1 {required Msg2   f1=1;}",

--- a/test/gpb_parse_tests.erl
+++ b/test/gpb_parse_tests.erl
@@ -766,6 +766,29 @@ can_prefix_record_names_test() ->
                  output=p_m2} %% ... and result msgs to be prefixed
       ]}] = do_process_sort_defs(Defs, [{msg_name_prefix, "p_"}]).
 
+can_prefix_record_names_by_proto_test() ->
+    {ok, Defs} = parse_lines(["enum    e1 {a=1; b=2;}",
+                              "message m1 {required e1 f1=1;}",
+                              "message m2 {required m1 f2=1;}",
+                              "service s1 {",
+                              "  rpc req(m1) returns (m2) {};",
+                              "}",
+                              "extend m1 { optional uint32 fm2=2; }"]),
+    Defs1 = [{{msg_containment, "proto1"}, [['.',m1]]},
+             {{msg_containment, "proto2"}, [['.',m2]]} | Defs],
+    [{{enum,e1},  [{a,1},{b,2}]}, %% not prefixed
+     {{msg,p1_m1}, [#?gpb_field{name=f1, type={enum,e1}}, #?gpb_field{name=fm2}]},
+     {{msg,p2_m2}, [#?gpb_field{type={msg,p1_m1}}]}, %% type is a msg: to be prefixed
+     {{msg_containment,"proto1"},[m1]},
+     {{msg_containment,"proto2"},[m2]},
+     {{service,s1}, %% not prefixed
+      [#?gpb_rpc{name=req,
+                 input=p1_m1,  %% both argument ...
+                 output=p2_m2} %% ... and result msgs to be prefixed
+      ]}] = do_process_sort_defs(Defs1, [{msg_name_prefix, {by_proto,
+                                                            [{proto1, "p1_"},
+                                                             {proto2, "p2_"}]}}]).
+
 can_suffix_record_names_test() ->
     {ok, Defs} = parse_lines(["enum    e1 {a=1; b=2;}",
                               "message m1 {required e1 f1=1;}",
@@ -799,13 +822,35 @@ can_tolower_record_names_test() ->
                  output=msg2} %% .. and result msgs to be to-lower
       ]}] = do_process_sort_defs(Defs, [msg_name_to_lower]).
 
+can_tolower_record_names_with_oneof_test() ->
+    {ok, Defs} = parse_lines(["message Msg1 {",
+                              "  oneof u {",
+                              "    Msg1   a = 1;",
+                              "    uint32 b = 2;",
+                              "  }",
+                              "}"]),
+    [{{msg,msg1}, [#gpb_oneof{fields=[#?gpb_field{name=a,type={msg,msg1}},
+                                      #?gpb_field{name=b}]}]}] =
+        do_process_sort_defs(Defs, [msg_name_to_lower]).
+
+can_tolower_record_names_with_map_test() ->
+    {ok, Defs} = parse_lines(["message Msg1 {",
+                              "  required uint32 f = 1;",
+                              "}"
+                              "message Msg2 {"
+                              "  map<string,Msg1> m = 1;",
+                              "}"]),
+    [{{msg,msg1}, [#?gpb_field{}]},
+     {{msg,msg2}, [#?gpb_field{type={map,string,{msg,msg1}}}]}] =
+        do_process_sort_defs(Defs, [msg_name_to_lower]).
+
 can_to_snake_record_names_test() ->
     {ok, Defs} = parse_lines(["message MsgName1 {required MsgName2   f1=1;}",
                               "message MsgName2 {required uint32 g1=1;}",
                               "service SvcName1 {",
                               "  rpc req(MsgName1) returns (MsgName2) {};",
                               "}",
-                              "extend Msg1 { optional uint32 fm2=2; }"]),
+                              "extend MsgName1 { optional uint32 fm2=2; }"]),
     [{{msg,msg_name_1}, [#?gpb_field{name=f1, type={msg,msg_name_2}},
                    #?gpb_field{name=fm2}]},
      {{msg,msg_name_2}, [#?gpb_field{name=g1}]},
@@ -813,7 +858,7 @@ can_to_snake_record_names_test() ->
       [#?gpb_rpc{name=req,
                  input=msg_name_1,  %% both argument ...
                  output=msg_name_2} %% .. and result msgs to be to-lower
-      ]}] = do_process_sort_defs(Defs, [msg_name_to_lower]).
+      ]}] = do_process_sort_defs(Defs, [msg_name_to_snake_case]).
 
 can_tolower_record_names_with_packages_test() ->
     {ok, Defs} = parse_lines(["package Pkg1;",


### PR DESCRIPTION
This PR covers the issues: #73 #74 and #75 

In addition to adding `msg_name_to_snake_case`, `by_proto` and the fixes for oneof/maps this also has a few changes to make it work better with rebar3. Mainly moving the `compile_descriptor` hook to a `pre_hook` instead of `post`.