### PR TITLE
fix use of by_proto on map types

### DIFF
--- a/src/gpb_parse.yrl
+++ b/src/gpb_parse.yrl
@@ -1145,7 +1145,8 @@ prefix_suffix_fields(Prefix, Suffix, ToLowerOrSnake, Fields, Defs) ->
                                               ToLowerOrSnake, MsgName),
               F#?gpb_field{type={msg,NewMsgName}};
          (#?gpb_field{type={map,KeyType,{msg,MsgName}}}=F) ->
-              NewMsgName = prefix_suffix_name(Prefix, Suffix,
+              Prefix1 = maybe_prefix_by_proto(MsgName, Prefix, Defs),
+              NewMsgName = prefix_suffix_name(Prefix1, Suffix,
                                               ToLowerOrSnake, MsgName),
               F#?gpb_field{type={map,KeyType,{msg,NewMsgName}}};
          (#gpb_oneof{fields=Fs}=F) ->

--- a/test/gpb_parse_tests.erl
+++ b/test/gpb_parse_tests.erl
@@ -770,6 +770,7 @@ can_prefix_record_names_by_proto_test() ->
     {ok, Defs} = parse_lines(["enum    e1 {a=1; b=2;}",
                               "message m1 {required e1 f1=1;}",
                               "message m2 {required m1 f2=1;}",
+                              "message m3 {map<string, m1> m=1;}",
                               "service s1 {",
                               "  rpc req(m1) returns (m2) {};",
                               "}",
@@ -777,6 +778,8 @@ can_prefix_record_names_by_proto_test() ->
     Defs1 = [{{msg_containment, "proto1"}, [['.',m1]]},
              {{msg_containment, "proto2"}, [['.',m2]]} | Defs],
     [{{enum,e1},  [{a,1},{b,2}]}, %% not prefixed
+     {{msg,m3},
+      [#?gpb_field{name=m, type={map,string,{msg,p1_m1}}}]},
      {{msg,p1_m1}, [#?gpb_field{name=f1, type={enum,e1}}, #?gpb_field{name=fm2}]},
      {{msg,p2_m2}, [#?gpb_field{type={msg,p1_m1}}]}, %% type is a msg: to be prefixed
      {{msg_containment,"proto1"},[m1]},


### PR DESCRIPTION
Just ran into this issue with a map using a type that needs to be prefixed in the generate code.