### PR TITLE
Fix symbolic link error of `protoc-erl`

### DIFF
--- a/bin/protoc-erl
+++ b/bin/protoc-erl
@@ -14,7 +14,14 @@ main(Argv) ->
     end.
 
 setup_code_path() ->
-    BinDir = filename:dirname(escript:script_name()),
+    ScriptName = escript:script_name(),
+    RealScriptName =
+    case file:read_link(ScriptName) of
+        {ok, Name} -> Name;
+        _ -> ScriptName
+    end,
+
+    BinDir = filename:dirname(RealScriptName),
     EBinDir = filename:join([BinDir, "..", "ebin"]),
     %% add the gpb ebin path to we can have access to gpb_compile
     true = code:add_pathz(EBinDir).

--- a/bin/protoc-erl
+++ b/bin/protoc-erl
@@ -15,16 +15,26 @@ main(Argv) ->
 
 setup_code_path() ->
     ScriptName = escript:script_name(),
-    RealScriptName =
-    case file:read_link(ScriptName) of
-        {ok, Name} -> Name;
-        _ -> ScriptName
-    end,
+    %% check symbolic link
+    RawFile = find_raw_file(ScriptName),
 
-    BinDir = filename:dirname(RealScriptName),
+    BinDir = filename:dirname(RawFile),
     EBinDir = filename:join([BinDir, "..", "ebin"]),
     %% add the gpb ebin path to we can have access to gpb_compile
     true = code:add_pathz(EBinDir).
+
+find_raw_file(Name) ->
+    find_raw_file(Name, file:read_link(Name)).
+
+find_raw_file(Name, {error, _}) ->
+    Name;
+
+find_raw_file(Name, {ok, Name1}) ->
+    %% for relative symbolic link
+    %% if Name1 is absolute, then AbsoluteName is Name1
+    DirName = filename:dirname(Name),
+    AbsoluteName = filename:join(DirName, Name1),
+    find_raw_file(AbsoluteName, file:read_link(AbsoluteName)).
 
 show_usage() ->
     io:format("usage: ~s [options] X.proto [...]~n",


### PR DESCRIPTION
When made a soft link of `protoc-erl`
(e.g. `ln -s PATH/gpb/bin/protoc-erl /usr/local/bin`,  to add `protoc-erl` in $PATH),
    
There will be an error occurred due to the wrong path.
So I add a link file check for handle this case.
