### PR TITLE
make default records fields and missing pb fields equivalent.

### DIFF
--- a/src/gpb_compile.erl
+++ b/src/gpb_compile.erl
@@ -6417,7 +6417,8 @@ format_record_typespec(Msg, Fields, Defs, Opts) ->
             ?f("-type ~p() ::~n"
                "      #{~s~n"
                "       }.",
-               [Msg, outdent_first(format_hfields(7 + 1, Fields, Opts, Defs))])
+               [Msg, outdent_first(format_hfields(Msg, 7 + 1,
+                                                  Fields, Opts, Defs))])
     end.
 
 format_export_types(Defs, Opts) ->
@@ -6481,12 +6482,13 @@ format_msg_record(Msg, Fields, Opts, Defs) ->
      ?f("-define(~p, true).~n", [Def]),
      ?f("-record(~p,~n", [Msg]),
      ?f("        {"),
-     outdent_first(format_hfields(8+1, Fields, Opts, Defs)),
+     outdent_first(format_hfields(Msg, 8+1, Fields, Opts, Defs)),
      "\n",
      ?f("        }).~n"),
      ?f("-endif.~n")].
 
-format_hfields(Indent, Fields, Opts, Defs) ->
+format_hfields(MsgName, Indent, Fields, Opts, Defs) ->
+    IsProto3 = gpb:is_msg_proto3(MsgName, Defs),
     TypeSpecs = get_type_specs_by_opts(Opts),
     MapsOrRecords = get_records_or_maps_by_opts(Opts),
     MappingAndUnset = get_mapping_and_unset_by_opts(Opts),
@@ -6515,30 +6517,41 @@ format_hfields(Indent, Fields, Opts, Defs) ->
                               true ->
                                    ""
                            end,
-                DefaultStr = case proplists:get_value(default, FOpts, '$no') of
-                                 '$no' ->
-                                     case {Type, Occur, MapsOrRecords} of
-                                         {{map,_,_}, repeated, records} ->
-                                             case MapTypeFieldsRepr of
-                                                 maps ->
-                                                     ?f(" = #{}");
-                                                 '2tuples' ->
-                                                     ?f(" = []")
-                                             end;
-                                         {_, repeated, records} ->
-                                             ?f(" = []");
-                                         _ ->
-                                             ""
-                                     end;
-                                 Default ->
-                                     case MapsOrRecords of
-                                         records ->
-                                             ?f(" = ~p", [Default]);
-                                         maps ->
-                                             ""
-                                     end
-                             end,
-                TypeStr = ?f("~s", [type_to_typestr(Field, Defs, Opts)]),
+                DefaultStr =
+                    case proplists:get_value(default, FOpts, '$no') of
+                        '$no' ->
+                            case {Type, Occur, MapsOrRecords} of
+                                {{map,_,_}, repeated, records} ->
+                                    case MapTypeFieldsRepr of
+                                        maps ->
+                                            ?f(" = #{}");
+                                        '2tuples' ->
+                                            ?f(" = []")
+                                    end;
+                                {_, repeated, records} ->
+                                    ?f(" = []");
+                                {_, _, records} ->
+                                    case IsProto3 of
+                                        true ->
+                                            Default =
+                                                proto3_type_default(Type,
+                                                                    Defs,
+                                                                    Opts),
+                                            ?f(" = ~p", [Default]);
+                                        false -> ""
+                                    end;
+                                _ ->
+                                    ""
+                            end;
+                        Default ->
+                            case MapsOrRecords of
+                                records ->
+                                    ?f(" = ~p", [Default]);
+                                maps ->
+                                    ""
+                            end
+                    end,
+                TypeStr = ?f("~s", [type_to_typestr(MsgName, Field, Defs, Opts)]),
                 CommaSep = if I < LastIndex -> ",";
                               true          -> "" %% last entry
                            end,
@@ -6568,7 +6581,7 @@ format_hfields(Indent, Fields, Opts, Defs) ->
                               true ->
                                    ""
                            end,
-                TypeStr = ?f("~s", [type_to_typestr(Field, Defs, Opts)]),
+                TypeStr = ?f("~s", [type_to_typestr(MsgName, Field, Defs, Opts)]),
                 CommaSep = if I < LastIndex -> ",";
                               true          -> "" %% last entry
                            end,
@@ -6657,7 +6670,8 @@ mandatory_map_item_type_sep(Opts) ->
 can_specify_map_item_presence_in_typespecs(Opts) ->
     is_target_major_version_at_least(19, Opts).
 
-type_to_typestr(#?gpb_field{type=Type, occurrence=Occurrence}, Defs, Opts) ->
+type_to_typestr(_MsgName, #?gpb_field{type=Type, occurrence=Occurrence},
+                Defs, Opts) ->
     OrUndefined = case get_mapping_and_unset_by_opts(Opts) of
                       records                   -> " | undefined";
                       {maps, present_undefined} -> " | undefined";
@@ -6674,7 +6688,7 @@ type_to_typestr(#?gpb_field{type=Type, occurrence=Occurrence}, Defs, Opts) ->
         optional ->
             type_to_typestr_2(Type, Defs, Opts) ++ OrUndefined
     end;
-type_to_typestr(#gpb_oneof{fields=OFields}, Defs, Opts) ->
+type_to_typestr(_, #gpb_oneof{fields=OFields}, Defs, Opts) ->
     OrUndefined = case get_mapping_and_unset_by_opts(Opts) of
                       records                   -> ["undefined"];
                       {maps, present_undefined} -> ["undefined"];
@@ -6725,7 +6739,7 @@ msg_to_typestr(M, Opts) ->
 %% when the strings_as_binaries option is requested the corresponding
 %% typespec should be spec'ed
 string_to_typestr(true) ->
-  "binary() | iolist()";
+  "iodata()";
 string_to_typestr(false) ->
   "iolist()".
 

--- a/test/gpb_compile_maps_tests.erl
+++ b/test/gpb_compile_maps_tests.erl
@@ -33,6 +33,8 @@ no_maps_tests__test() ->
 -else. %% NO_HAVE_MAPS
 
 -import(gpb_compile_tests, [compile_iolist/2]).
+-import(gpb_compile_tests, [compile_to_string_get_hrl/2]).
+-import(gpb_compile_tests, [compile_erl_iolist/1]).
 -import(gpb_compile_tests, [unload_code/1]).
 
 -import(gpb_compile_tests, [nif_tests_check_prerequisites/1]).
@@ -397,6 +399,20 @@ default_value_handling_test() ->
                           [pass_as_record]],
         OptVariation2 <- [[{maps_unset_optional,present_undefined}],
                           [{maps_unset_optional,omitted}]]].
+
+defaults_for_proto3_fields_test() ->
+    Proto = ["syntax=\"proto3\";\n",
+             "message m {",
+             "  map<int32, int32> mii = 41;",
+             "}"],
+    P3M = compile_erl_iolist(
+             ["-export([new_m_msg/0]).\n",
+              compile_to_string_get_hrl(
+                Proto,
+                [type_specs, strip_preprocessor_lines, mapfields_as_maps]),
+              "new_m_msg() -> #m{}.\n"]),
+    {m, #{}} = P3M:new_m_msg(),
+    unload_code(P3M).
 
 %% --- target versions ----------------------------------
 


### PR DESCRIPTION
Currently when generating using the proto3 syntax, `#foo{} =/= foo:decode(<<>>)`, which is kind of painful, especially when testing.  This PR makes it such that default fields are no longer undefined, but rather set to their type default, which should make them more like the output of decode.  Sub-messages are left as undefined; I'm not sure what the specification suggests, but I went with this behavior to match that of decode.