### PR TITLE
Extend parser to include Custom Options

### DIFF
--- a/src/gpb_parse.yrl
+++ b/src/gpb_parse.yrl
@@ -98,7 +98,7 @@ package_def -> package name ';':        {package, '$2'}.
 name -> '.' identifiers:                ['.' | '$2'].
 name -> identifiers:                    '$1'.
 
-option_name_ident -> identifier:        '$1'.
+option_name_ident -> identifier:        [identifier_name('$1')].
 option_name_ident -> '(' name ')':      '$2'.
 
 option_name -> option_name_ident:           '$1'.

--- a/src/gpb_parse.yrl
+++ b/src/gpb_parse.yrl
@@ -38,6 +38,7 @@ Nonterminals
         group_def
         service_def rpc_defs rpc_def rpc_arg rpc_ret m_opts
         name
+        option_name
         constant
         integer
         string_expr
@@ -96,13 +97,17 @@ package_def -> package name ';':        {package, '$2'}.
 name -> '.' identifiers:                ['.' | '$2'].
 name -> identifiers:                    '$1'.
 
+option_name -> name:                       '$1'.
+option_name -> '(' name ')':               '$2'.
+option_name -> option_name '.' name:       '$1' ++ '$3'.
+
 identifiers -> identifier '.' identifiers:      [identifier_name('$1'), '.'
                                                  | '$3'].
 identifiers -> identifier:                      [identifier_name('$1')].
 
 import_def -> import str_lit ';':       {import, literal_value('$2')}.
 
-option_def -> option name '=' constant: {option, '$2', '$4'}.
+option_def -> option option_name '=' constant: {option, '$2', '$4'}.
 
 enum_def -> enum fidentifier '{' enum_fields '}':
                                         {{enum,identifier_name('$2')},'$4'}.

--- a/src/gpb_parse.yrl
+++ b/src/gpb_parse.yrl
@@ -31,6 +31,7 @@ Nonterminals
         package_def
         import_def
         identifiers
+        option_name_ident
         extend_def extensions_def exts ext
         reserved_def res_numbers res_number res_names
         oneof_def oneof_elems oneof_elem
@@ -97,9 +98,11 @@ package_def -> package name ';':        {package, '$2'}.
 name -> '.' identifiers:                ['.' | '$2'].
 name -> identifiers:                    '$1'.
 
-option_name -> name:                       '$1'.
-option_name -> '(' name ')':               '$2'.
-option_name -> option_name '.' name:       '$1' ++ '$3'.
+option_name_ident -> identifier:        '$1'.
+option_name_ident -> '(' name ')':      '$2'.
+
+option_name -> option_name_ident:           '$1'.
+option_name -> option_name_ident '.' name:  '$1' ++ '$3'.
 
 identifiers -> identifier '.' identifiers:      [identifier_name('$1'), '.'
                                                  | '$3'].

--- a/test/gpb_parse_tests.erl
+++ b/test/gpb_parse_tests.erl
@@ -663,7 +663,9 @@ parses_rpc_streams_and_options_test() ->
                              "  rpc r2(stream m1) returns (m2);",
                              "  rpc r3(m1)        returns (stream m2);",
                              "  rpc r4(stream m1) returns (stream m2);",
-                             "  rpc ro(m1) returns (m2) { option a=1; }",
+                             "  rpc ro(m1) returns (m2) { option a=1; };",
+                             "  rpc ro(m1) returns (m2) { option (a).b=1; };",
+                             "  rpc ro(m1) returns (m2) { option (a.b).c=1; };",
                              "}"]),
     [{{msg,m1}, _},
      {{msg,m2}, _},
@@ -672,7 +674,9 @@ parses_rpc_streams_and_options_test() ->
        #?gpb_rpc{name=r2, input_stream=true, output_stream=false},
        #?gpb_rpc{name=r3, input_stream=false, output_stream=true},
        #?gpb_rpc{name=r4, input_stream=true, output_stream=true},
-       #?gpb_rpc{name=ro, opts=[{a,1}]}]=Rpcs}] =
+       #?gpb_rpc{name=ro, opts=[{'a',1}]},
+       #?gpb_rpc{name=ro, opts=[{'a.b',1}]},
+       #?gpb_rpc{name=ro, opts=[{'a.b.c',1}]}]=Rpcs}] =
         do_process_sort_defs(Defs),
     %% Check all input(arg)/output(return) messages too
     [{m1,m2}] = lists:usort([{A,R} || #?gpb_rpc{input=A,output=R} <- Rpcs]).


### PR DESCRIPTION
As per [Custom Options](https://developers.google.com/protocol-buffers/docs/proto#options) in the Protobufs spec, this patch extends the parser in `gpb` to include the ability to specify custom option extensions.

E.g., we now allow:

```protobuf
import "google/protobuf/descriptor.proto";

extend google.protobuf.MessageOptions {
  optional string my_option = 51234;
}

message MyMessage {
  option (my_option) = "Hello world!";
}
```

and, more complexly:

```protobuf
service MyService {
  option (my_service_option) = FOO;

  rpc MyMethod(RequestType) returns(ResponseType) {
    // Note:  my_method_option has type MyMessage.  We can set each field
    //   within it using a separate "option" line.
    option (my_method_option).foo = 567;
    option (my_method_option).bar = "Some string";
  }
}
```

I am relatively new to `yecc`, so please feel free to add feedback if there is a more correct or canonical way to approach this. I can also add test cases, but I wanted to get feedback sooner than later.

This pull request addresses issue #107.