### PR TITLE
Bugfix for erlang maps encoding/decoding when maps_unset_optional is set to omitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ Repeated fields are represented as lists.
 Optional fields are represented as either the value or `undefined` if
 not set. However, for maps, if the option `maps_unset_optional` is set
 to `omitted`, then unset optional values are omitted from the map,
-instead of being set to `undefined`.
+instead of being set to `undefined` when encoding messages. When
+decoding messages, even with `maps_unset_optional` set to `omitted,
+the default value will be set in the decoded map.
 
 Examples of Erlang format for protocol buffer messages
 ------------------------------------------------------


### PR DESCRIPTION
When encoding/decoding as maps (and maps_unset_optional set to omitted), the merge message function clause should not treat repeated fields as
required.