### PR TITLE
apply tolower or snakecase to rpc names as well

### DIFF
--- a/src/gpb_parse.yrl
+++ b/src/gpb_parse.yrl
@@ -1333,7 +1333,7 @@ prefix_suffix_rpcs(Prefix, Suffix, ToLowerOrSnake, RPCs, Defs) ->
                                                   ToLowerOrSnake, Arg),
                       NewReturn = prefix_suffix_name(PrefixReturn, Suffix,
                                                      ToLowerOrSnake, Return),
-                      R#?gpb_rpc{name=RpcName,
+                      R#?gpb_rpc{name=maybe_tolower_or_snake_name(RpcName, ToLowerOrSnake),
                                  input=NewArg,
                                  output=NewReturn}
               end,


### PR DESCRIPTION
Useful with https://github.com/Bluehouse-Technology/grpc to have function names that don't require single quoting.