### PR TITLE
Fix math.h / cmath clash on some glibc versions

### DIFF
--- a/src/gpb_gen_nif.erl
+++ b/src/gpb_gen_nif.erl
@@ -130,13 +130,30 @@ format_nif_cc_includes(Mod, Defs, AnRes, _Opts) ->
     IsLiteRT = is_lite_rt(Defs),
     ["#include <string.h>\n",
      "#include <string>\n",
-     ["#include <math.h>\n" || is_any_field_of_type_float_or_double(AnRes)],
      "\n",
      "#include <erl_nif.h>\n",
      "\n",
      ?f("#include \"~s.pb.h\"\n", [Mod]),
      ["#include <google/protobuf/message_lite.h>\n" || IsLiteRT],
+     format_math_include(AnRes),
      "\n"].
+
+format_math_include(AnRes) ->
+    case is_any_field_of_type_float_or_double(AnRes) of
+        true ->
+            ["#include <math.h>\n",
+            "#include <cmath>\n",
+             "#ifndef isnan\n",
+             "# define isnan std::isnan\n",
+             "#endif\n",
+             "\n",
+             "#ifndef isinf\n",
+             "# define isinf std::isinf\n",
+             "#endif\n",
+            "\n"];
+        false ->
+            ""
+    end.
 
 format_nif_cc_oneof_version_check_if_present(Defs) ->
     case contains_oneof(Defs) of


### PR DESCRIPTION
Hi and thank you for your work on this library.

First and foremost, I am very sorry to make you aware of this ugly glibc issue today.

The code generated by `gpb` would not compile on some servers. The errors are the following (I selected the relevant parts):

```
_build/default/lib/some_project/c_src/somefile.nif.cc:5550:20: error: 'isnan' was not declared in this scope           
         if (isnan(v))   
...
_build/default/lib/some_project/c_src/some_file.nif.cc:5552:25: error: 'isinf' was not declared in this scope           
         else if (isinf(v) && v < 0)
```

The reason is well summarized here: https://stackoverflow.com/a/39133379/65124
and protobuf itself also works around it: [here](https://github.com/protocolbuffers/protobuf/blob/d9ccd0c0e6bbda9bf4476088eeb46b02d7dcd327/src/google/protobuf/stubs/mathlimits.h#L48-L61) and [also here](https://github.com/protocolbuffers/protobuf/blob/d9ccd0c0e6bbda9bf4476088eeb46b02d7dcd327/src/google/protobuf/stubs/mathlimits.h#L237-L243)

I am unsure if this patch is the best way to go, but it's making sure `math.h` is included before `cmath`, and after protobuf is included. That way, if any macro undefine is done by the glibc header, we then point to the correct function to use.