### PR TITLE
some spec issue fix

### DIFF
--- a/src/gpb_gen_introspect.erl
+++ b/src/gpb_gen_introspect.erl
@@ -685,7 +685,7 @@ compute_enum_infos(EnumDefs, Package, #anres{renamings = Renamings}, Opts) ->
      || {{enum,EnumName}, _Syms} <- EnumDefs].
 
 format_fqbin_to_enum_name(EnumInfos) ->
-    [["-spec enum_name_to_fqbin(_) -> no_return().\n" || EnumInfos == []],
+    [["-spec fqbin_to_enum_name(_) -> no_return().\n" || EnumInfos == []],
      gpb_codegen:format_fn(
        fqbin_to_enum_name,
        fun('<<"maybe.package.EnumName">>') -> 'EnumName';
@@ -699,7 +699,7 @@ format_fqbin_to_enum_name(EnumInfos) ->
            || {FqEnumName, EnumName} <- EnumInfos])])].
 
 format_enum_name_to_fqbin(EnumInfos) ->
-    [["-spec fqbin_to_enum_name(_) -> no_return().\n" || EnumInfos == []],
+    [["-spec enum_name_to_fqbin(_) -> no_return().\n" || EnumInfos == []],
      gpb_codegen:format_fn(
        enum_name_to_fqbin,
        fun('EnumName') -> '<<"maybe.package.EnumName">>';

--- a/src/gpb_gen_types.erl
+++ b/src/gpb_gen_types.erl
@@ -413,8 +413,7 @@ type_to_typestr_2(sfixed32, _Defs, _Opts) -> "integer()";
 type_to_typestr_2(sfixed64, _Defs, _Opts) -> "integer()";
 type_to_typestr_2(float, _Defs, _Opts)    -> float_spec();
 type_to_typestr_2(double, _Defs, _Opts)   -> float_spec();
-type_to_typestr_2(string, _Defs, Opts)    ->
-  string_to_typestr(gpb_lib:get_strings_as_binaries_by_opts(Opts));
+type_to_typestr_2(string, _Defs, _Opts)   -> "iodata()";
 type_to_typestr_2(bytes, _Defs, _Opts)    -> "iodata()";
 type_to_typestr_2({enum,E}, Defs, Opts)   -> enum_typestr(E, Defs, Opts);
 type_to_typestr_2({msg,M}, _Defs, Opts)   -> msg_to_typestr(M, Opts);
@@ -438,13 +437,6 @@ msg_to_typestr(M, Opts) ->
       ?f("~p:~p()", [Mod, M]);
     maps -> ?f("~p()", [M])
   end.
-
-%% when the strings_as_binaries option is requested the corresponding
-%% typespec should be spec'ed
-string_to_typestr(true) ->
-  "iodata()";
-string_to_typestr(false) ->
-  "binary() | iolist()".
 
 enum_typestr(E, Defs, Opts) ->
     UnknownEnums = case proplists:get_bool(nif, Opts) of

--- a/src/gpb_gen_types.erl
+++ b/src/gpb_gen_types.erl
@@ -444,7 +444,7 @@ msg_to_typestr(M, Opts) ->
 string_to_typestr(true) ->
   "iodata()";
 string_to_typestr(false) ->
-  "iolist()".
+  "binary() | iolist()".
 
 enum_typestr(E, Defs, Opts) ->
     UnknownEnums = case proplists:get_bool(nif, Opts) of


### PR DESCRIPTION
Hi there,
always get following errors when running dialyzer checking, please kindly consider merging this PR. Thanks a lot.

> function fqbin_to_enum_name/1: at line 625: @spec name does not match.

> 68: Record construction #on_connect_r{connection_ref::binary()} violates the declared type of field connection_ref::'undefined' | maybe_improper_list(binary() | maybe_improper_list(any(),binary() | []) | byte(),binary() | [])