### PR TITLE
Use Erlang's ++ to concatenate string will affect the compatibility for Elixir

### DIFF
--- a/src/gpb_lib.erl
+++ b/src/gpb_lib.erl
@@ -785,7 +785,7 @@ drop_filename_ext(Path) ->
     filename:join(lists:reverse(RRest, [BNoExt])).
 
 copy_filename_ext(FilenameSansExt, FilenameToCopyFrom) ->
-    FilenameSansExt ++ filename:extension(FilenameToCopyFrom).
+    iolist_to_binary([FilenameSansExt, filename:extension(FilenameToCopyFrom)]).
 
 %% @doc Compute filenames (paths) to basenames
 %% but include last part(s) of the directories as necessary


### PR DESCRIPTION
Hello, 

Here's an error issue in Elixir

```
Erlang/OTP 22 [erts-10.4.3] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [hipe] [dtrace]

Interactive Elixir (1.9.0) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> :gpb_lib.copy_filename_ext("basic", "./test/proto/basic.proto")
** (ArgumentError) argument error
    :erlang.++("basic", ".proto")
    (gpb) src/gpb_lib.erl:788: :gpb_lib.copy_filename_ext/2
iex(1)>
```

In my investigation, this issue was introduced from 4.7.0 by this [commit](https://github.com/tomas-abrahamsson/gpb/commit/77daf173f16a66626cd02bee3e666a107f47da60), please review.