### PR TITLE
Apply renames to the enum type also in export_type

### DIFF
--- a/src/gpb_gen_types.erl
+++ b/src/gpb_gen_types.erl
@@ -59,7 +59,7 @@ format_export_types(Defs, AnRes, Opts) ->
                                 || {{enum, Enum}, Enumeration} <- Defs]),
                "\n",
                ?f("-export_type([~s]).",
-                  [gpb_lib:comma_join(["'"++atom_to_list(Enum)++"'/0"
+                  [gpb_lib:comma_join([format_enum_export(Enum, AnRes)
                                        || {{enum, Enum}, _} <- Defs])]),
                "\n\n",
                "%% message types\n",
@@ -79,6 +79,10 @@ format_enum_typespec(Enum, Enumeration, AnRes) ->
     Enumerators = gpb_lib:or_join([?f("~p", [EName])
                                    || {EName, _} <- Enumeration]),
     ?f("-type ~p() :: ~s.", [Enum1, Enumerators]).
+
+format_enum_export(Enum, AnRes) ->
+    Enum1 = rename_enum_type(Enum, AnRes),
+    ?f("~p/0", [Enum1]).
 
 format_record_typespec(Msg, Fields, Defs, AnRes, Opts) ->
     MsgType = rename_msg_type(Msg, AnRes),

--- a/test/gpb_compile_tests.erl
+++ b/test/gpb_compile_tests.erl
@@ -858,7 +858,19 @@ enum_from_binary_test() ->
     <<"foo.bar.E1">> = M3:enum_name_to_fqbin('foo.bar.E1'),
     'foo.bar.msg.E2' = M3:fqbin_to_enum_name(<<"foo.bar.Msg.E2">>),
     <<"foo.bar.Msg.E2">> = M3:enum_name_to_fqbin('foo.bar.msg.E2'),
-    unload_code(M3).
+    unload_code(M3),
+
+    %% With the use_package _and_ rename options, with enum type renaming
+    M4 = compile_iolist(Proto1,
+                        [use_packages,
+                        {rename,{msg_name,lowercase}},
+                        {rename,{enum_typename,lowercase}},
+                        type_specs]),
+    'foo.bar.E1' = M4:fqbin_to_enum_name(<<"foo.bar.E1">>),
+    <<"foo.bar.E1">> = M4:enum_name_to_fqbin('foo.bar.E1'),
+    'foo.bar.msg.E2' = M4:fqbin_to_enum_name(<<"foo.bar.Msg.E2">>),
+    <<"foo.bar.Msg.E2">> = M4:enum_name_to_fqbin('foo.bar.msg.E2'),
+    unload_code(M4).
 
 sources_and_basenames_test() ->
     M = compile_protos(


### PR DESCRIPTION
Closes #185

With the added test case, but without the fix in gpb_gen_types, the test fails with:
```
**error:{badmatch,{error,[{"gpb_compile_tests-tmp-1.erl",
                   [{71,erl_lint,{undefined_type,{'foo.bar.E1',0}}},
                    {71,erl_lint,{undefined_type,{'foo.bar.msg.E2',0}}}]}],
                 [{"gpb_compile_tests-tmp-1.erl",
                   [{69,erl_lint,{unused_type,{'foo.bar.e1',0}}},
                    {70,erl_lint,{unused_type,{'foo.bar.msg.e2',0}}}]}]}}
```