### PR TITLE
respect `REBAR_BARE_COMPILER_OUTPUT_DIR` env var during descriptor compilation

### DIFF
--- a/build/compile_descriptor
+++ b/build/compile_descriptor
@@ -39,18 +39,27 @@ check_ok_or_halt(Res) ->
        true -> halt(1)
     end.
 
+deps_dir() ->
+    case os:getenv("REBAR_DEPS_DIR") of
+        false ->
+            os:getenv("REBAR_BARE_COMPILER_OUTPUT_DIR");
+        DepsDir ->
+            DepsDir
+    end.
+
 main(_) ->
-    REBAR_DEPS_DIR = os:getenv("REBAR_DEPS_DIR"),
+    REBAR_DEPS_DIR = deps_dir(),
     {EbinPath, TestPath} =
         case REBAR_DEPS_DIR =/= false
             andalso filelib:is_dir(filename:join(REBAR_DEPS_DIR, "gpb")) of
             true ->
-                Ebin = filename:join([REBAR_DEPS_DIR, "gpb", "ebin"]),
-                filelib:ensure_dir(filename:join(Ebin, ".dummy")),
-                {Ebin, filename:join([REBAR_DEPS_DIR, "gpb", "test"])};
+                {filename:join([REBAR_DEPS_DIR, "gpb", "ebin"]),
+                 filename:join([REBAR_DEPS_DIR, "gpb", "test"])};
             _ ->
                 {"./ebin", "./test"}
         end,
+
+    filelib:ensure_dir(filename:join(EbinPath, ".dummy")),
 
     CheckList =
         [{["descr_src/gpb_descriptor.erl",


### PR DESCRIPTION
closes #204 

this appears to fix my compilation with elixir 1.12

~I'm a bit worried that this is just a band-aid fix of some other issue. I can't seem to hunt down what exactly changed in the elixir source that would cause this to be necessary~

it looks like rebar recently added support for this environment variable (see https://github.com/erlang/rebar3/pull/2237) which mix started passing to rebar in elixir 1.12