### PR TITLE
Support maps for definitions

### DIFF
--- a/src/gpb.erl
+++ b/src/gpb.erl
@@ -1898,12 +1898,19 @@ fetch_field_by_name(Name, Fields) ->
 
 -endif. % -ifndef(NO_HAVE_MAPS).
 
-keyfetch(Key, KVPairs) ->
+keyfetch(Key, MsgDefs) ->
+    case keyfetch_2(Key, MsgDefs) of
+        undefined -> erlang:error({error, {no_such_key, Key, MsgDefs}});
+        Value -> Value
+    end.
+
+keyfetch_2(Key, MsgDefs) when is_map(MsgDefs) ->
+    maps:get(Key, MsgDefs, undefined);
+
+keyfetch_2(Key, KVPairs) when is_list(KVPairs) ->
     case lists:keysearch(Key, 1, KVPairs) of
-        {value, {Key, Value}} ->
-            Value;
-        false ->
-            erlang:error({error, {no_such_key, Key, KVPairs}})
+        {value, {Key, Value}} -> Value;
+        false -> undefined
     end.
 
 is_field_for_unknowns(#?gpb_field{type=unknown, occurrence=repeated}) ->

--- a/src/gpb_defs.erl
+++ b/src/gpb_defs.erl
@@ -46,7 +46,7 @@
 
 -define(is_non_empty_string(Str), (is_list(Str) andalso is_integer(hd(Str)))).
 
--type defs() :: [def()].
+-type defs() :: [def()] | map().
 -type def() :: {proto_defs_version, version()} |
                {{msg, Name::atom()}, [field()]} |
                {{group, Name::atom()}, [field()]} |


### PR DESCRIPTION
This is the second optimization mentioned in #217. As you proposed there, the new code still works with the current format (list). Note that I was deliberately sloppy with the typespec for the new format, because it would require a lot of duplication with the existing def.

Personally, I think that going forward the new format should be preferred. In this case, we could provide a detailed spec for the map, while using the relaxed `list()` spec for the "legacy" format.

Of course, we could always have two detailed specs, but maintaining this is going to be more difficult and error prone.

I don't have a strong opinion though, so let me know what you prefer.