### PR TITLE
fix: Improve on `gpb_defs`'s for possible result

### DIFF
--- a/src/gpb_defs.erl
+++ b/src/gpb_defs.erl
@@ -61,6 +61,7 @@
                {{service, Name::atom()}, [#?gpb_rpc{}]} |
                {package, Name::atom()} |
                {syntax, string()} | % "proto2" | "proto3"
+               {option, Name::atom(), Val::term()} |
                {{extensions, MsgName::atom()}, [field_number_extension()]} |
                {{extend, MsgName::atom()}, MoreFields::[field()]} |
                {{ext_origin,MsgName::atom()}, {atom(), MoreFields::[field()]}} |


### PR DESCRIPTION
Found this while consuming the result of `gpb_parse:parse/1` on a file that contains an option.