### PR TITLE
fix: support binary map keys in unions

### DIFF
--- a/src/gpb_gen_verifiers.erl
+++ b/src/gpb_gen_verifiers.erl
@@ -655,7 +655,11 @@ field_oneof_omitted_flat_verifier(MsgName, FName, OFields,
                                   FVar, MsgVar, TrUserDataVar,
                                   AnRes, Opts) ->
     %% FIXME: Verify at most one oneof field is set
-    OFNames = gpb_lib:get_field_names(OFields),
+    OFNames0 = gpb_lib:get_field_names(OFields),
+    OFNames = case gpb_lib:get_maps_key_type_by_opts(Opts) of
+                  atom -> OFNames0;
+                  binary -> lists:map(fun(X) -> atom_to_binary(X, utf8) end, OFNames0)
+              end,
     ?expr(
        case 'M' of
            '#{OFName := OFVar}' ->
@@ -958,6 +962,7 @@ atom_to_stree(Atom) ->
     erl_syntax:atom(Atom).
 
 atom_to_binary_string_stree(Atom) ->
+    Cs = atom_to_list(Atom),
     erl_syntax:binary(
       [erl_syntax:binary_field(
-         erl_syntax:string(atom_to_list(Atom)))]).
+         erl_syntax:integer(C)) || C <- Cs]).

--- a/src/gpb_lib.erl
+++ b/src/gpb_lib.erl
@@ -614,9 +614,10 @@ mapkey_literal_by_opts(Opts) ->
             fun(Atom) -> erl_syntax:atom(Atom) end;
         binary ->
             fun(Atom) ->
+                    Cs = atom_to_list(Atom),
                     erl_syntax:binary(
                            [erl_syntax:binary_field(
-                              erl_syntax:string(atom_to_list(Atom)))])
+                              erl_syntax:integer(C)) || C <- Cs])
             end
     end.
 
@@ -626,11 +627,9 @@ mapkey_expr_by_opts(Opts) ->
             fun(Expr) -> Expr end;
         binary ->
             fun(Expr) ->
-                    erl_syntax:binary(
-                      [erl_syntax:binary_field(
-                         erl_syntax:application(erl_syntax:atom(erlang),
-                                                erl_syntax:atom(atom_to_list),
-                                                [Expr]))])
+                    erl_syntax:application(erl_syntax:atom(erlang),
+                                           erl_syntax:atom(atom_to_binary),
+                                           [Expr, erl_syntax:atom(utf8)])
             end
     end.
 

--- a/test/gpb_compile_maps_tests.erl
+++ b/test/gpb_compile_maps_tests.erl
@@ -676,6 +676,33 @@ flat_oneof_with_translation_with_typespec_maps_test_aux() ->
             ]),
     ?assert(gpb_lib:is_substr("a1=>string()", strip_ws(Erl))).
 
+flat_oneof_with_maps_key_type_binary_test() ->
+    M = compile_iolist([ "message test {"
+                       , "  map<string, string> args = 1;"
+                       , "}"
+                       , "message union {"
+                       , "  oneof u {"
+                       , "    int32 a = 1;"
+                       , "    string b = 2;"
+                       , "  }"
+                       , "}"
+                       ],
+                       [{maps, true},
+                        {maps_oneof, flat},
+                        {maps_key_type, binary},
+                        {maps_unset_optional, omitted},
+                        strings_as_binaries,
+                        {verify, always}]),
+    MapInput1 = #{<<"args">> => #{<<"hello">> => <<"world">>}},
+    MapData1 = M:encode_msg(MapInput1, test),
+    ?assertEqual(MapInput1, M:decode_msg(MapData1, test)),
+    UnionInput1 = #{<<"a">> => 1},
+    UnionData1 = M:encode_msg(UnionInput1, union),
+    ?assertEqual(UnionInput1, M:decode_msg(UnionData1, union)),
+    UnionInput2 = #{<<"b">> => <<"hello">>},
+    UnionData2 = M:encode_msg(UnionInput2, union),
+    ?assertEqual(UnionInput2, M:decode_msg(UnionData2, union)),
+    unload_code(M).
 
 strip_ws(B) when is_list(B) ->
     binary_to_list(


### PR DESCRIPTION
Previously, when using maps with binary keys, flat unions and verification, unions would not work, even with binary map keys as expected.

For example, with the following definitions:

```erlang
Src = """
syntax = "proto3";

message test {
  map<string, string> args = 1;
}

message union {
  oneof u {
    int32 a = 1;
    string b = 2;
  }
}
""".
{ok, Mod, Bin} = gpb_compile:string(aaa, Src, [binary, strings_as_binaries, {maps, true}, {maps_oneof, flat}, {maps_key_type, binary}, {verify, always}, {maps_unset_optional, omitted}]).
code:load_binary(Mod, "aaa.erl", Bin).
```

... normal maps work as expected:

```erlang
7>   Encoded1 = Mod:encode_msg(#{<<"args">> => #{<<"hey">> => <<"hi">>}}, test).
 <<10,9,10,3,104,101,121,18,2,104,105>>
8>   Mod:decode_msg(Encoded1, test).
 #{<<"args">> => #{<<"hey">> => <<"hi">>}}
```

... but unions break, due to verifier failing to consider binary keys when encoding:

```erlang
20>   %% Should produce <<8, 1>>.
      Mod:encode_msg(#{<<"a">> => 1}, union).
** exception error: {gpb_type_error,{{multiple_oneof_keys,[],u},
                                     [{value,#{<<"a">> => 1}},{path,"union.u"}]}}
     in function  aaa:mk_type_error/3 (aaa.erl, line 567)
     in call from aaa:encode_msg/3 (aaa.erl, line 79)

```

... and decoding due to incorrect generated code which produced `<<(atom_to_list(SomeAtom))>>` for the map key:

```erlang
21>   Mod:decode_msg(<<8, 1>>, union).
** exception error: {gpb_error,{decoding_failure,{<<8,1>>,
                                                  union,
                                                  {error,badarg,
                                                         [{aaa,dfp_read_field_def_union,6,
                                                               [{file,"aaa.erl"},
                                                                {line,292},
                                                                {error_info,#{cause => {1,integer,type,"a"},
                                                                              function => format_bs_fail,module => erl_erts_errors}}]},
                                                          {aaa,decode_msg_1_catch,3,[{file,"aaa.erl"},{line,227}]},
                                                          {erl_eval,do_apply,7,[{file,"erl_eval.erl"},{line,919}]},
                                                          {shell,exprs,7,[{file,"shell.erl"},{line,916}]},
                                                          {shell,eval_exprs,7,[{file,"shell.erl"},{line,872}]},
                                                          {shell,restricted_eval_loop,5,
                                                                 [{file,"shell.erl"},{line,866}]}]}}}}
     in function  aaa:decode_msg_1_catch/3 (aaa.erl, line 231)
```